### PR TITLE
auth.getMobileSession should use HTTPS

### DIFF
--- a/lib/lastfm/lastfm-request.js
+++ b/lib/lastfm/lastfm-request.js
@@ -81,7 +81,7 @@ var LastFmRequest = module.exports = function(lastfm, method, params) {
     return params.signed || isWriteRequest() || isSignedMethod(method);
   }
 
-  function isWriteRequest(mathod) {
+  function isWriteRequest(method) {
     return params.write || isWriteMethod(method);
   }
 


### PR DESCRIPTION
According to the [documentation](http://www.last.fm/api/show/auth.getMobileSession), the `auth.getMobileSession` method will not work over plain HTTP. HTTPS should be used instead.

The returned error object looks like this:

``` javascript
{ error: 4,
  message: 'You must use HTTPS in order to use this method.',
  links: [] }
```
