### PR TITLE
Add trailing slash to API url

### DIFF
--- a/lib/lastfm/index.js
+++ b/lib/lastfm/index.js
@@ -6,7 +6,7 @@ var RecentTracksStream = require("./recenttracks-stream"),
 
 var LastFmNode = exports.LastFmNode = function(options) {
   options = options || {};
-  this.url = "/2.0";
+  this.url = "/2.0/";
   this.host = options.host || "ws.audioscrobbler.com";
   this.format = "json";
   this.secret = options.secret;


### PR DESCRIPTION
Last.fm apparently requires this now! Without it, every response returns a `301 Moved Permanently` code.