### PR TITLE
Empty tracks fix

### DIFF
--- a/lib/lastfm/recenttracks-stream.js
+++ b/lib/lastfm/recenttracks-stream.js
@@ -57,8 +57,16 @@ var RecentTracksStream = module.exports = function(lastfm, user, options) {
 
       var tracks = data.recenttracks.track;
       if (tracks instanceof Array) {
-        processNowPlaying(tracks[0]);
-        processLastPlay(tracks[1]);
+        if (tracks.length == 0) {
+          return;
+        }
+        if (tracks.length == 1) {
+          processNowPlaying(tracks[0]);
+        }
+        if (tracks.length > 1) {
+          processNowPlaying(tracks[0]);
+          processLastPlay(tracks[1]);
+        }
         return;
       }
 


### PR DESCRIPTION
A fix for the following error I've gotten:

```
UNCAUGHT EXCEPTION! NodeCG will now exit.
TypeError: Cannot read property 'name' of undefined
    at processNowPlaying (C:\dev\nodecg\bundles\ncg-djwg\node_modules\lastfm\lib\lastfm\recenttracks-stream.js:98:60) < Line number might have changed
    at EventEmitter.handleSuccess (C:\dev\nodecg\bundles\ncg-djwg\node_modules\lastfm\lib\lastfm\recenttracks-stream.js:62:9)
    at emitOne (events.js:77:13)
    at EventEmitter.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (C:\dev\nodecg\bundles\ncg-djwg\node_modules\lastfm\lib\lastfm\lastfm-request.js:123:14)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at doNTCallback2 (node.js:441:9)
    at process._tickCallback (node.js:355:17)
```

Since `data` was:

```
data { recenttracks:
   { track: [],
     '@attr':
      { user: 'Spiky',
        page: '1',
        perPage: '1',
        totalPages: '0',
        total: '0' } } }
```

And I've also seen one variation with only one track, which was not "now playing".

Couldn't get the tests to run.. Might need a hand there for updated tests.
